### PR TITLE
fix(backend): Correct Vercel deployment configuration

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,5 +1,15 @@
 {
-    "version": 2,
-    "builds": [{ "src": "server.js", "use": "@vercel/node" }],
-    "routes": [{ "src": "/(.*)", "dest": "/server.ts" }]
+  "version": 2,
+  "builds": [
+    {
+      "src": "server.ts",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "server.ts"
+    }
+  ]
 }


### PR DESCRIPTION
The `vercel.json` file was misconfigured, causing the backend to fail on Vercel.

- The build configuration was pointing to `server.js` instead of the TypeScript source `server.ts`.
- The routes destination was incorrect.

This change updates `backend/vercel.json` to correctly configure the build and routing for a standalone Vercel deployment. This assumes the Vercel project's "Root Directory" is set to `backend`.